### PR TITLE
avoid clobbering loop counter

### DIFF
--- a/nkf.c
+++ b/nkf.c
@@ -5436,8 +5436,8 @@ mime_putc(nkf_char c)
 		mimeout_state.buf[mimeout_state.count++] = (char)c;
 		if (mimeout_state.count>MIMEOUT_BUF_LENGTH) {
 		    eof_mime();
-		    for (i=0;i<mimeout_state.count;i++) {
-			(*o_mputc)(mimeout_state.buf[i]);
+		    for (j=0;i<mimeout_state.count;j++) {
+			(*o_mputc)(mimeout_state.buf[j]);
 			base64_count++;
 		    }
 		    mimeout_state.count = 0;


### PR DESCRIPTION
This was safe, because the outer loop ends here.  But was definitely a
bad habit, and reusing local variable to save memory is a lame
technique.

cf: https://bugs.ruby-lang.org/issues/12202