### PR TITLE
Fix typos

### DIFF
--- a/NKF.mod/NKF.pm
+++ b/NKF.mod/NKF.pm
@@ -99,7 +99,7 @@ For X0201 kana, SO/SI, SSO and ESC-(-I methods are supported.
 For automatic code detection, nkf assumes no X0201 kana in Shift_JIS.
 To accept X0201 in Shift_JIS, use B<-X>, B<-x> or B<-S>.
 
-multiple options are specifed as seprate strings, such as
+multiple options are specified as seprate strings, such as
 
   print nkf('--ic=UTF8-MAC', '-w', $string), "\n";
 
@@ -139,13 +139,13 @@ UTF-8N.
 
 UTF-16.
 B or L gives whether Big Endian or Little Endian.
-0 gives whther put BOM or not.
+0 gives whether put BOM or not.
 
 =item B<-W32[BL][0]>
 
 UTF-32.
 B or L gives whether Big Endian or Little Endian.
-0 gives whther put BOM or not.
+0 gives whether put BOM or not.
 
 =back
 

--- a/NKF.mod/NKF.xs
+++ b/NKF.mod/NKF.xs
@@ -102,7 +102,7 @@ nkf_putchar_grow(unsigned int c)
 
 /* package defenition  */
 
-/* nkf accepts variable length arugments. The last argument is */
+/* nkf accepts variable length arguments. The last argument is */
 /* the input data. Other strings are flags for nkf translation.    */
 
 MODULE = NKF		PACKAGE = NKF		

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ cf. --ic and --oc.
 
     UTF-16.
     B or L gives whether Big Endian or Little Endian.
-    0 gives whther put BOM or not.
+    0 gives whether put BOM or not.
 
     - __-W32[BL][0]__
 
     UTF-32.
     B or L gives whether Big Endian or Little Endian.
-    0 gives whther put BOM or not.
+    0 gives whether put BOM or not.
 
 - __-b -u__
 

--- a/config.h
+++ b/config.h
@@ -30,7 +30,7 @@
 /* --exec-in, --exec-out option
  * require pipe, fork, execvp and so on.
  * please undef this on MS-DOS, MinGW
- * this is still buggy arround child process
+ * this is still buggy around child process
  */
 /* #define EXEC_IO */
 

--- a/man/nkf.1.pm
+++ b/man/nkf.1.pm
@@ -77,7 +77,7 @@ For X0201 kana, SO/SI, SSO and ESC-(-I methods are supported.
 For automatic code detection, nkf assumes no X0201 kana in Shift_JIS.
 To accept X0201 in Shift_JIS, use B<-X>, B<-x> or B<-S>.
 
-multiple options are specifed as seprate strings, such as
+multiple options are specified as seprate strings, such as
 
   print nkf('--ic=UTF8-MAC', '-w', $string), "\n";
 
@@ -117,13 +117,13 @@ UTF-8N.
 
 UTF-16.
 B or L gives whether Big Endian or Little Endian.
-0 gives whther put BOM or not.
+0 gives whether put BOM or not.
 
 =item B<-W32[BL][0]>
 
 UTF-32.
 B or L gives whether Big Endian or Little Endian.
-0 gives whther put BOM or not.
+0 gives whether put BOM or not.
 
 =back
 

--- a/nkf.1
+++ b/nkf.1
@@ -158,7 +158,7 @@ For X0201 kana, \s-1SO/SI, SSO\s0 and \s-1ESC\-\s0(\-I methods are supported.
 For automatic code detection, nkf assumes no X0201 kana in Shift_JIS.
 To accept X0201 in Shift_JIS, use \fB\-X\fR, \fB\-x\fR or \fB\-S\fR.
 .PP
-multiple options are specifed as seprate strings, such as
+multiple options are specified as seprate strings, such as
 .PP
 .Vb 1
 \&  print nkf(\*(Aq\-\-ic=UTF8\-MAC\*(Aq, \*(Aq\-w\*(Aq, $string), "\en";
@@ -191,12 +191,12 @@ EUC-JP.
 .IX Item "-W16[BL][0]"
 \&\s-1UTF\-16.
 B\s0 or L gives whether Big Endian or Little Endian.
-0 gives whther put \s-1BOM\s0 or not.
+0 gives whether put \s-1BOM\s0 or not.
 .IP "\fB\-W32[\s-1BL\s0][0]\fR" 4
 .IX Item "-W32[BL][0]"
 \&\s-1UTF\-32.
 B\s0 or L gives whether Big Endian or Little Endian.
-0 gives whther put \s-1BOM\s0 or not.
+0 gives whether put \s-1BOM\s0 or not.
 .RE
 .RS 4
 .RE

--- a/utf8tbl.c
+++ b/utf8tbl.c
@@ -1,5 +1,5 @@
 /*
- * utf8tbl.c - Convertion Table for nkf
+ * utf8tbl.c - Conversion Table for nkf
  *
  */
 

--- a/utf8tbl.h
+++ b/utf8tbl.h
@@ -1,5 +1,5 @@
 /*
- * utf8tbl.h - Header file for Convertion Table
+ * utf8tbl.h - Header file for Conversion Table
  *
  */
 


### PR DESCRIPTION
This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell). 

```
$ misspell .
NKF.mod/NKF.pm:102:21: "specifed" is a misspelling of "specified"
NKF.mod/NKF.pm:142:8: "whther" is a misspelling of "whether"
NKF.mod/NKF.pm:148:8: "whther" is a misspelling of "whether"
NKF.mod/NKF.xs:105:31: "arugments" is a misspelling of "arguments"
config.h:33:23: "arround" is a misspelling of "around"
man/nkf.1.pm:80:21: "specifed" is a misspelling of "specified"
man/nkf.1.pm:120:8: "whther" is a misspelling of "whether"
man/nkf.1.pm:126:8: "whther" is a misspelling of "whether"
README.md:64:12: "whther" is a misspelling of "whether"
README.md:70:12: "whther" is a misspelling of "whether"
nkf.1:161:21: "specifed" is a misspelling of "specified"
nkf.1:194:8: "whther" is a misspelling of "whether"
nkf.1:199:8: "whther" is a misspelling of "whether"
utf8tbl.h:2:31: "Convertion" is a misspelling of "Conversion"
utf8tbl.c:2:15: "Convertion" is a misspelling of "Conversion"
```

see also: https://github.com/ruby/ruby/pull/1925