### PR TITLE
Add generated files by 'make test && make perl && make python2' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ NKF.mod/NKF.bs
 NKF.mod/NKF.c
 NKF.mod/blib/
 NKF.mod/pm_to_blib
+NKF.mod/MYMETA.json
+NKF.mod/MYMETA.yml
+NKF.python2/build/


### PR DESCRIPTION
This pull request adds the following to .gitignore. They're also generated when running `make test && make perl && make python2`, but we don't need to manage in the git repository. If I am wrong, please correct me and feel free to close this PR without merging it.

* NKF.mod/MYMETA.json
* NKF.mod/MYMETA.yml
* NKF.python2/build/

